### PR TITLE
feat: Implement non-blocking AI moves and enhance engine stability

### DIFF
--- a/engine/stockfish_adapter.py
+++ b/engine/stockfish_adapter.py
@@ -13,6 +13,9 @@ class StockfishAdapter:
         self.analysis_thread = None
         self.analysis_queue = queue.Queue() # Pour récupérer les résultats de l'analyse
         self.current_analysis_info = None   # Stocke la dernière info d'analyse complète
+        
+        self.ai_move_queue = queue.Queue(maxsize=1)
+        self.ai_move_thread = None # To store the thread for AI move calculation
 
         try:
             if not os.path.exists(config.STOCKFISH_PATH):
@@ -54,7 +57,10 @@ class StockfishAdapter:
             
             # Mettre le résultat (la dernière info de la ligne principale) dans la queue
             # 'info' contient 'score', 'pv' (meilleure variante), 'depth', etc.
-            self.analysis_queue.put(info)
+            if info: # Ensure info is not None
+                self.analysis_queue.put(info.copy()) # Put a copy of the info dictionary
+            else:
+                self.analysis_queue.put(None) # Or handle as an error/no result
             
         except chess.engine.EngineTerminatedError:
             print("ERREUR: Le moteur Stockfish s'est terminé de manière inattendue pendant l'analyse.")
@@ -70,12 +76,18 @@ class StockfishAdapter:
             print("ATTENTION: Stockfish non initialisé, analyse impossible.")
             return
 
-        # Si une analyse est déjà en cours, on pourrait l'arrêter ou l'ignorer
+        # If a thread object exists from a previous call and is dead, join it.
+        if self.analysis_thread:
+            if not self.analysis_thread.is_alive():
+                # Previous thread existed but is dead, try to join it to ensure cleanup.
+                # print("DEBUG: Previous analysis thread found dead, joining...")
+                self.analysis_thread.join(timeout=0.2) # Wait up to 0.2s
+                self.analysis_thread = None # Set to None after join for a clean state
+
+        # If an analysis is already running (could be the same thread object if join timed out or new one started fast)
         if self.analysis_thread and self.analysis_thread.is_alive():
-            # print("DEBUG: Analyse précédente toujours en cours, nouvelle analyse ignorée ou en attente.")
-            # Pour une version simple, on ne lance pas une nouvelle si une est en cours.
-            # Pour une version plus avancée, on pourrait tuer l'ancien thread ou utiliser une gestion plus fine.
-            return 
+            # print("DEBUG: Analysis thread still alive, new analysis request ignored.")
+            return # Previous analysis is still running, do nothing.
 
         # Vider la queue des résultats précédents
         while not self.analysis_queue.empty():
@@ -120,6 +132,64 @@ class StockfishAdapter:
         except Exception as e:
             print(f"ERREUR: lors de la demande du meilleur coup à Stockfish: {e}")
             return None
+
+    def _calculate_ai_move_in_background(self, board_fen: str, time_limit_ms: int):
+        if not self.engine:
+            self.ai_move_queue.put(None)
+            return
+
+        try:
+            # Create a new board instance for the thread
+            thread_board = chess.Board(fen=board_fen)
+            # Call the existing synchronous method to get the best move
+            # Note: get_best_move_from_engine expects a board object.
+            move = self.get_best_move_from_engine(thread_board, time_limit_ms=time_limit_ms)
+            self.ai_move_queue.put(move)
+        except Exception as e:
+            print(f"ERREUR: Exception dans le thread de calcul de coup IA: {e}")
+            self.ai_move_queue.put(None) # Ensure queue gets something to unblock getter
+
+    def request_ai_move(self, board: chess.Board, time_limit_ms: int):
+        if not self.engine:
+            print("ATTENTION: Stockfish non initialisé, calcul de coup IA impossible.")
+            # Optionally, put None in queue if GameScreen expects a response
+            # self.ai_move_queue.put(None) 
+            return
+
+        # Manage previous ai_move_thread (similar to analysis_thread)
+        if self.ai_move_thread:
+            if not self.ai_move_thread.is_alive():
+                self.ai_move_thread.join(timeout=0.1) # Short timeout for cleanup
+                self.ai_move_thread = None
+            else:
+                # An AI move calculation is already in progress
+                print("DEBUG: Calcul de coup IA précédent toujours en cours.")
+                return 
+
+        # Clear the queue before starting a new request
+        while not self.ai_move_queue.empty():
+            try:
+                self.ai_move_queue.get_nowait()
+            except queue.Empty:
+                break
+        
+        board_fen = board.fen()
+        self.ai_move_thread = threading.Thread(
+            target=self._calculate_ai_move_in_background,
+            args=(board_fen, time_limit_ms)
+        )
+        self.ai_move_thread.daemon = True
+        self.ai_move_thread.start()
+        # print(f"DEBUG: Thread de calcul de coup IA démarré pour FEN: {board_fen}") # Optional
+
+    def get_completed_ai_move(self) -> chess.Move | None:
+        try:
+            move = self.ai_move_queue.get_nowait() # Non-blocking
+            # print(f"DEBUG: Coup récupéré de la queue IA: {move}") # Optional
+            return move
+        except queue.Empty:
+            # print("DEBUG: Queue de coup IA vide.") # Optional
+            return None # No move ready yet
 
     def close(self):
         """Arrête proprement le moteur Stockfish."""

--- a/game_logic/player.py
+++ b/game_logic/player.py
@@ -15,6 +15,8 @@ class Player:
         """
         Décrémente le temps du joueur.
         """
+        if self.time_left_ms == float('inf'):
+            return  # Do nothing if time is infinite
         if not self.is_timed_out:
             self.time_left_ms -= delta_ms
             if self.time_left_ms <= 0:
@@ -26,6 +28,8 @@ class Player:
         """
         Retourne le temps restant formaté en 'MM:SS.d' (minutes:secondes.dixiemes).
         """
+        if self.time_left_ms == float('inf'):
+            return "∞" # Or use "--:--" if preferred, but "∞" is more standard.
         if self.is_timed_out:
             return "00:00.0"
 


### PR DESCRIPTION
- I implemented a non-blocking mechanism for AI move calculations to prevent UI freezes during AI thinking time.
- AI move requests are now handled in a separate thread.
- GameScreen manages AI thinking states and applies moves after a 1-second visual delay once calculated.
- I reinstated a join() call with timeout in StockfishAdapter's analysis thread management to improve stability, though an asyncio InvalidStateError may still intermittently occur in AI vs AI games' sidebar analysis.